### PR TITLE
Isolate questionnaire pages from the WordPress theme.

### DIFF
--- a/questionnaire-plugin/questionnaire-plugin.php
+++ b/questionnaire-plugin/questionnaire-plugin.php
@@ -556,34 +556,37 @@ function questionnaire_list_page() {
 }
 
 function questionnaire_enqueue_assets() {
-    // Deregister default WP jQuery and register the custom version in the header
-    wp_deregister_script('jquery');
-    wp_register_script('jquery-custom', plugin_dir_url(__FILE__) . 'assets/js_from_site/jquery-1.12.1.min.js', [], '1.12.1', false);
+    global $post;
+    if (is_a($post, 'WP_Post') && has_shortcode($post->post_content, 'questionnaire')) {
+        // Deregister default WP jQuery and register the custom version in the header
+        wp_deregister_script('jquery');
+        wp_register_script('jquery-custom', plugin_dir_url(__FILE__) . 'assets/js_from_site/jquery-1.12.1.min.js', [], '1.12.1', false);
 
-    // Enqueue styles from the site
-    wp_enqueue_style('bootstrap-min', plugin_dir_url(__FILE__) . 'assets/css_from_site/bootstrap.min.css');
-    wp_enqueue_style('bootstrap-icons-min', plugin_dir_url(__FILE__) . 'assets/css_from_site/bootstrap-icons.min.css');
-    wp_enqueue_style('qualify', plugin_dir_url(__FILE__) . 'assets/css_from_site/qualify.css');
-    wp_enqueue_style('utils-min-css', plugin_dir_url(__FILE__) . 'assets/css_from_site/utils.min.css');
+        // Enqueue styles from the site
+        wp_enqueue_style('bootstrap-min', plugin_dir_url(__FILE__) . 'assets/css_from_site/bootstrap.min.css');
+        wp_enqueue_style('bootstrap-icons-min', plugin_dir_url(__FILE__) . 'assets/css_from_site/bootstrap-icons.min.css');
+        wp_enqueue_style('qualify', plugin_dir_url(__FILE__) . 'assets/css_from_site/qualify.css');
+        wp_enqueue_style('utils-min-css', plugin_dir_url(__FILE__) . 'assets/css_from_site/utils.min.css');
 
-    // Enqueue scripts from the site, making them dependent on the custom jQuery
-    wp_enqueue_script('jquery-custom'); // Enqueue the registered script
-    wp_enqueue_script('bootstrap-bundle-min', plugin_dir_url(__FILE__) . 'assets/js_from_site/bootstrap.bundle.min.js', ['jquery-custom'], null, true);
-    wp_enqueue_script('utils-min-js', plugin_dir_url(__FILE__) . 'assets/js_from_site/utils.min.js', ['jquery-custom'], null, true);
-    wp_enqueue_script('29752987', plugin_dir_url(__FILE__) . 'assets/js_from_site/29752987.js', ['jquery-custom'], null, true);
-    wp_enqueue_script('everflow', plugin_dir_url(__FILE__) . 'assets/js_from_site/everflow.js', ['jquery-custom'], null, true);
-    wp_enqueue_script('gtm', plugin_dir_url(__FILE__) . 'assets/js_from_site/gtm.js', ['jquery-custom'], null, true);
-    wp_enqueue_script('matomo', plugin_dir_url(__FILE__) . 'assets/js_from_site/matomo.js', ['jquery-custom'], null, true);
-    wp_enqueue_script('smartlook', plugin_dir_url(__FILE__) . 'assets/js_from_site/smartlook.js', ['jquery-custom'], null, true);
-    wp_enqueue_script('tp-widget-bootstrap', plugin_dir_url(__FILE__) . 'assets/js_from_site/tp.widget.bootstrap.min.js', ['jquery-custom'], null, true);
+        // Enqueue scripts from the site, making them dependent on the custom jQuery
+        wp_enqueue_script('jquery-custom'); // Enqueue the registered script
+        wp_enqueue_script('bootstrap-bundle-min', plugin_dir_url(__FILE__) . 'assets/js_from_site/bootstrap.bundle.min.js', ['jquery-custom'], null, true);
+        wp_enqueue_script('utils-min-js', plugin_dir_url(__FILE__) . 'assets/js_from_site/utils.min.js', ['jquery-custom'], null, true);
+        wp_enqueue_script('29752987', plugin_dir_url(__FILE__) . 'assets/js_from_site/29752987.js', ['jquery-custom'], null, true);
+        wp_enqueue_script('everflow', plugin_dir_url(__FILE__) . 'assets/js_from_site/everflow.js', ['jquery-custom'], null, true);
+        wp_enqueue_script('gtm', plugin_dir_url(__FILE__) . 'assets/js_from_site/gtm.js', ['jquery-custom'], null, true);
+        wp_enqueue_script('matomo', plugin_dir_url(__FILE__) . 'assets/js_from_site/matomo.js', ['jquery-custom'], null, true);
+        wp_enqueue_script('smartlook', plugin_dir_url(__FILE__) . 'assets/js_from_site/smartlook.js', ['jquery-custom'], null, true);
+        wp_enqueue_script('tp-widget-bootstrap', plugin_dir_url(__FILE__) . 'assets/js_from_site/tp.widget.bootstrap.min.js', ['jquery-custom'], null, true);
 
-    // Enqueue the plugin's custom logic script, also dependent on custom jQuery
-    wp_enqueue_script('questionnaire-script', plugin_dir_url(__FILE__) . 'assets/js/main.js', ['jquery-custom'], '1.0', true);
+        // Enqueue the plugin's custom logic script, also dependent on custom jQuery
+        wp_enqueue_script('questionnaire-script', plugin_dir_url(__FILE__) . 'assets/js/main.js', ['jquery-custom'], '1.0', true);
 
-    // Pass data to script
-    wp_localize_script('questionnaire-script', 'questionnaire_ajax', [
-        'ajax_url' => admin_url('admin-ajax.php')
-    ]);
+        // Pass data to script
+        wp_localize_script('questionnaire-script', 'questionnaire_ajax', [
+            'ajax_url' => admin_url('admin-ajax.php')
+        ]);
+    }
 }
 add_action('wp_enqueue_scripts', 'questionnaire_enqueue_assets');
 
@@ -717,4 +720,16 @@ function handle_answer_submission() {
 }
 add_action('wp_ajax_handle_answer_submission', 'handle_answer_submission');
 add_action('wp_ajax_nopriv_handle_answer_submission', 'handle_answer_submission');
+
+function questionnaire_template_redirect($template) {
+    global $post;
+    if (is_singular() && has_shortcode($post->post_content, 'questionnaire')) {
+        $new_template = plugin_dir_path(__FILE__) . 'templates/questionnaire-page-template.php';
+        if ('' != $new_template) {
+            return $new_template;
+        }
+    }
+    return $template;
+}
+add_filter('template_include', 'questionnaire_template_redirect');
 ?>

--- a/questionnaire-plugin/templates/questionnaire-page-template.php
+++ b/questionnaire-plugin/templates/questionnaire-page-template.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+    <?php
+    while ( have_posts() ) :
+        the_post();
+        the_content();
+    endwhile;
+    ?>
+    <?php wp_footer(); ?>
+</body>
+</html>


### PR DESCRIPTION
This change introduces a custom page template for questionnaire pages, which prevents the theme's header and footer from being loaded. It also conditionally loads the plugin's CSS and JavaScript assets only on pages containing the `[questionnaire]` shortcode.

This resolves two issues:
1. The WordPress theme no longer interferes with the layout of questionnaire pages.
2. The plugin's styles no longer affect other pages on the WordPress site.