### PR TITLE
feat: Isolate questionnaire pages from WP theme

### DIFF
--- a/questionnaire-plugin/page-questionnaire.php
+++ b/questionnaire-plugin/page-questionnaire.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * The template for displaying questionnaire pages.
+ */
+
+// We don't want any of the theme's styling to interfere, so we'll build the page from scratch.
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?php wp_title('|', true, 'right'); ?></title>
+    <?php
+    // We will manually enqueue our scripts and styles
+    do_action('questionnaire_head');
+    ?>
+</head>
+<body <?php body_class(); ?>>
+    <?php
+    // The content of the questionnaire page will be injected here
+    while (have_posts()) :
+        the_post();
+        the_content();
+    endwhile;
+
+    // We will manually enqueue our footer scripts
+    do_action('questionnaire_footer');
+    ?>
+</body>
+</html>

--- a/questionnaire-plugin/questionnaire-plugin.php
+++ b/questionnaire-plugin/questionnaire-plugin.php
@@ -89,9 +89,6 @@ function qp_render_questionnaire_page($atts) {
     if (file_exists($template_path)) {
         $content = file_get_contents($template_path);
 
-        // Replace asset paths
-        $content = str_replace('../assets', plugin_dir_url(__FILE__) . 'assets', $content);
-
         // Replace page links
         preg_match_all('/href="([^"]*?\.php)"/', $content, $matches);
 
@@ -115,6 +112,44 @@ function qp_render_questionnaire_page($atts) {
     return '<!-- Template not found: ' . esc_html($atts['template']) . ' -->';
 }
 add_shortcode('questionnaire_page', 'qp_render_questionnaire_page');
+
+function qp_enqueue_questionnaire_styles() {
+    if (is_singular('page') && has_shortcode(get_post()->post_content, 'questionnaire_page')) {
+        $plugin_url = plugin_dir_url(__FILE__);
+
+        echo '<link rel="stylesheet" id="bootstrap-css" href="' . $plugin_url . 'assets/css/bootstrap.min.css" type="text/css" media="all" />';
+        echo '<link rel="stylesheet" id="bootstrap-icons-css" href="' . $plugin_url . 'assets/css/bootstrap-icons.min.css" type="text/css" media="all" />';
+        echo '<link rel="stylesheet" id="qualify-css" href="' . $plugin_url . 'assets/css/qualify.css" type="text/css" media="all" />';
+        echo '<link rel="stylesheet" id="style-css" href="' . $plugin_url . 'assets/css/style.css" type="text/css" media="all" />';
+    }
+}
+add_action('questionnaire_head', 'qp_enqueue_questionnaire_styles');
+
+function qp_enqueue_questionnaire_scripts() {
+    if (is_singular('page') && has_shortcode(get_post()->post_content, 'questionnaire_page')) {
+        $plugin_url = plugin_dir_url(__FILE__);
+
+        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/jquery-1.12.1.min.js" id="jquery-custom-js"></script>';
+        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/bootstrap.bundle.min.js" id="bootstrap-bundle-js"></script>';
+        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/main.js" id="main-js"></script>';
+        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/everflow.js" id="everflow-js"></script>';
+        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/smartlook.js" id="smartlook-js"></script>';
+    }
+}
+add_action('questionnaire_footer', 'qp_enqueue_questionnaire_scripts');
+
+function qp_template_include($template) {
+    // Check if we are on a single page that has our shortcode
+    if (is_singular('page') && has_shortcode(get_post()->post_content, 'questionnaire_page')) {
+        $new_template = plugin_dir_path(__FILE__) . 'page-questionnaire.php';
+        if (file_exists($new_template)) {
+            return $new_template;
+        }
+    }
+    return $template;
+}
+add_filter('template_include', 'qp_template_include', 99);
+
 
 function qp_start_session() {
     if (!session_id()) {


### PR DESCRIPTION
This commit introduces a custom page template for the questionnaire pages to prevent the WordPress theme's styles, header, and footer from being applied.

- Creates a new `page-questionnaire.php` template with a minimal HTML structure.
- Uses the `template_include` filter to conditionally load the custom template for pages containing the `[questionnaire_page]` shortcode.
- Replaces the previous method of hardcoding asset paths with a more robust system that hooks into the new template's custom actions (`questionnaire_head` and `questionnaire_footer`).
- This ensures that the plugin's pages have a consistent appearance and do not conflict with the active theme.