### PR TITLE
fix: Prevent automatic redirection on questionnaire pages

### DIFF
--- a/questionnaire-plugin/questionnaire-plugin.php
+++ b/questionnaire-plugin/questionnaire-plugin.php
@@ -89,6 +89,9 @@ function qp_render_questionnaire_page($atts) {
     if (file_exists($template_path)) {
         $content = file_get_contents($template_path);
 
+        // Replace asset paths
+        $content = str_replace('../assets', plugin_dir_url(__FILE__) . 'assets', $content);
+
         // Replace page links
         preg_match_all('/href="([^"]*?\.php)"/', $content, $matches);
 
@@ -112,31 +115,6 @@ function qp_render_questionnaire_page($atts) {
     return '<!-- Template not found: ' . esc_html($atts['template']) . ' -->';
 }
 add_shortcode('questionnaire_page', 'qp_render_questionnaire_page');
-
-function qp_enqueue_questionnaire_styles() {
-    if (is_singular('page') && has_shortcode(get_post()->post_content, 'questionnaire_page')) {
-        $plugin_url = plugin_dir_url(__FILE__);
-
-        echo '<link rel="stylesheet" id="bootstrap-css" href="' . $plugin_url . 'assets/css/bootstrap.min.css" type="text/css" media="all" />';
-        echo '<link rel="stylesheet" id="bootstrap-icons-css" href="' . $plugin_url . 'assets/css/bootstrap-icons.min.css" type="text/css" media="all" />';
-        echo '<link rel="stylesheet" id="qualify-css" href="' . $plugin_url . 'assets/css/qualify.css" type="text/css" media="all" />';
-        echo '<link rel="stylesheet" id="style-css" href="' . $plugin_url . 'assets/css/style.css" type="text/css" media="all" />';
-    }
-}
-add_action('questionnaire_head', 'qp_enqueue_questionnaire_styles');
-
-function qp_enqueue_questionnaire_scripts() {
-    if (is_singular('page') && has_shortcode(get_post()->post_content, 'questionnaire_page')) {
-        $plugin_url = plugin_dir_url(__FILE__);
-
-        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/jquery-1.12.1.min.js" id="jquery-custom-js"></script>';
-        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/bootstrap.bundle.min.js" id="bootstrap-bundle-js"></script>';
-        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/main.js" id="main-js"></script>';
-        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/everflow.js" id="everflow-js"></script>';
-        echo '<script type="text/javascript" src="' . $plugin_url . 'assets/js/smartlook.js" id="smartlook-js"></script>';
-    }
-}
-add_action('questionnaire_footer', 'qp_enqueue_questionnaire_scripts');
 
 function qp_template_include($template) {
     // Check if we are on a single page that has our shortcode


### PR DESCRIPTION
This commit resolves a bug where questionnaire pages would automatically redirect to the 'Thank You' page upon loading.

The issue was caused by a conflict between the centrally injected `main.js` (designed for an SPA-style interaction) and the static HTML templates (which use a traditional multi-page form submission flow).

The fix involves:
1. Removing the `qp_enqueue_questionnaire_styles` and `qp_enqueue_questionnaire_scripts` functions that were injecting the conflicting assets.
2. Restoring the `str_replace` logic in `qp_render_questionnaire_page` to correctly resolve asset paths within the HTML templates, allowing them to load their own required CSS and JS files.

This change ensures the questionnaire functions as intended while still being isolated from the main WordPress theme.