### PR TITLE
fix: Correct price mismatch and redirect error in NMI integration

### DIFF
--- a/questionnaire-plugin.php
+++ b/questionnaire-plugin.php
@@ -495,7 +495,6 @@ function qp_handle_checkout_submission() {
     // Set payment gateway and other order details
     $order->set_total($price);
 
-    $order->calculate_totals();
     $order->save();
 
     // Set payment gateway
@@ -520,7 +519,8 @@ function qp_handle_checkout_submission() {
         $order->payment_complete();
         unset($_SESSION['WeightLossAdvocates_data']);
         unset($_SESSION['WeightLossAdvocates_order_id']);
-        wp_redirect($result['redirect']);
+        // Redirect to the WooCommerce standard thank you page
+        wp_redirect($order->get_checkout_order_received_url());
         exit;
     } else {
         $order->update_status('failed', 'Payment failed.');


### PR DESCRIPTION
This commit addresses two critical issues identified after the initial integration of the WooCommerce NMI payment gateway.

1.  **Price Mismatch:** The `calculate_totals()` method was being called on the order object after the custom price was set. This caused WooCommerce to recalculate the total based on the product's default price, overriding the correct price from the questionnaire. This function call has been removed.

2.  **Redirect Error:** The NMI gateway's success redirect URL was causing a critical error in WordPress. The redirection logic has been updated to use the standard WooCommerce function `$order->get_checkout_order_received_url()`, ensuring a stable and correct redirection to the "Order Received" page.